### PR TITLE
Fix None Rewards on SimpleRenderWrapper.close()

### DIFF
--- a/textarena/wrappers/RenderWrappers/SimpleRenderWrapper/render.py
+++ b/textarena/wrappers/RenderWrappers/SimpleRenderWrapper/render.py
@@ -499,3 +499,5 @@ class SimpleRenderWrapper(RenderWrapper):
                 self._save_video()
             except Exception as e:
                 print(f"Error during cleanup: {e}")
+        
+        return self.env.close()


### PR DESCRIPTION
SimpleRenderWrapper.close() closes without calling env.close() resulting in None Rewards