### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ apt install enchant2
 ```
 
 ### Play Offline
+Run the following command to set your OpenRouter API key:
+```bash
+export OPENROUTER_API_KEY="YOUR_OPENROUTER_API_KEY"
+```
+
+Then run the following code to play offline:
+
 ```python
 import textarena as ta
 


### PR DESCRIPTION
When running locally, the template code provided causes an error since an openrouter API key isn't set. 