### PR TITLE
Fix WordLadder (extension of [https://github.com/LeonGuertler/TextArena/pull/59](old pr))

### DIFF
--- a/textarena/envs/two_player/ConnectFour/env.py
+++ b/textarena/envs/two_player/ConnectFour/env.py
@@ -69,7 +69,7 @@ class ConnectFourEnv(ta.Env):
             f"Your disc symbol: {'X' if player_id == 0 else 'O'}.\n"
             f"The game board has {self.num_rows} rows and {self.num_cols} columns.\n"
             f"Players take turns dropping their disc into one of the columns (0 to {self.num_cols - 1}).\n"
-            "First to connect four discs vertically, horizontally, or diagonally wins.\n"
+            "The first to connect (their own) four discs vertically, horizontally, or diagonally wins.\n"
             "On your turn, enter the column number in squared brackets to make your move.\n"
             "For example: '[col 4]' or '[col 1]'.\n"
         )


### PR DESCRIPTION
WordLadder but more efficient and harder words
* depends slightly on the changes in env.utils.word_lists but a more general change
* fixes the graph algorithm to work better for hard words

* The old hard mode was actually easier than the easy mode because the adjacencies were found in the adjacency graph made from basic words only (thus more sparse)
* New mode uses larger list of words to determine adjacency...
* To do so uses more efficient algorithms

Examples before / after
Easy [before]  gold -> band 
['gold', 'cold', 'cord', 'card', 'hard', 'hand', 'band'] ❌ (intended)
['gold', 'bold', 'bond', 'band'] ✅ (easily found)
Easy [after] page -> mass
['page', 'pate', 'bate', 'bats', 'bass', 'mass']
Medium [before] sky -> law
['sky', 'say', 'ray', 'rat', 'cat', 'cut', 'nut', 'not', 'now', 'low', 'law'] ❌
['sky', 'say', 'lay', 'law'] ✅ 
Medium [after] work from ['work', 'cork', 'corp', 'coop', 'clop', 'flop', 'flog', 'frog', 'from']
Hard [before] rod -> cow
['rod', 'red', 'bed', 'bad', 'sad', 'say', 'ray', 'rat', 'cat', 'cut', 'nut', 'not', 'now', 'cow']❌
['rod', 'cod', 'cow'] ✅ 
Hard [after] shame -> loose
['shame', 'shale', 'stale', 'stile', 'stilt', 'stint', 'saint', 'paint', 'point', 'joint', 'joist', 'joust', 'roust', 'rouse', 'louse', 'loose']