### PR TITLE
Add Bedrock Agent Samples in Stratego Game

### DIFF
--- a/samples/Stratego game with Claude Sonnet models on Bedrock/README.md
+++ b/samples/Stratego game with Claude Sonnet models on Bedrock/README.md
@@ -1,0 +1,55 @@
+# Stratego AI Bedrock Agents Battle
+
+A project that simulates Stratego games between two AWS Bedrock agents (Claude 3.5 Sonnet and Claude 3.7 Sonnet) using the TextArena library.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+* Python 3.x (Recommended: Python 3.8 or later)
+* AWS Account with access to AWS Bedrock
+* AWS CLI installed and configured (Recommended)
+* Boto3 library (AWS SDK for Python)
+* TextArena library
+
+## Installation
+
+Install the required dependencies:
+
+```bash
+pip install boto3 textarena
+```
+
+## Configuration
+Setting Up AWS Credentials
+You have two options for configuring AWS credentials:
+
+### Option 1: Environment Variables
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+```
+
+### Option 2: AWS CLI
+
+```bash
+aws configure
+```
+
+## Usage
+
+1. Set your AWS Region
+
+```bash
+export AWS_REGION="us-west-2"
+```
+
+2. Run your sample code
+
+Make sure you are in the right directory:
+
+```bash
+python sample.py
+```
+

--- a/samples/Stratego game with Claude Sonnet models on Bedrock/sample.py
+++ b/samples/Stratego game with Claude Sonnet models on Bedrock/sample.py
@@ -1,0 +1,36 @@
+import textarena as ta
+from textarena.agents.basic_agents import AWSBedrockAgent
+import os
+
+# Initialize AWS Bedrock Agent using environment variables
+agents = {
+    0: AWSBedrockAgent(
+        model_id="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        region_name=os.getenv("AWS_REGION"),
+        verbose=True,
+    ),
+    1: AWSBedrockAgent(
+        model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        region_name=os.getenv("AWS_REGION"),
+        verbose=True,
+    ),
+}
+
+# Initialize environment
+env = ta.make("Stratego-v0")
+env = ta.wrappers.LLMObservationWrapper(env=env)
+env = ta.wrappers.SimpleRenderWrapper(
+    env=env,
+    player_names={0: "Claude 3.5 Sonnet V2", 1: "Claude 3.7 Sonnet"},
+)
+env.reset()
+done = False
+
+# Run the simulation
+while not done:
+    player_id, observation = env.get_observation()
+    action = agents[player_id](observation)
+    done, info = env.step(action=action)
+
+env.close()
+print("Game Over!")


### PR DESCRIPTION
This PR adds README instruction and a sample code to help users get started with the Stratego AI simulation using AWS Bedrock agents (Claude 3.5 and 3.7 Sonnet).

