### PR TITLE
fix: update kuhnpoker env

### DIFF
--- a/textarena/envs/KuhnPoker/env.py
+++ b/textarena/envs/KuhnPoker/env.py
@@ -104,7 +104,6 @@ class KuhnPokerEnv(ta.Env):
         starting_player = 1 - self.state.game_state["starting_player"]
         self.state.game_state["starting_player"] = starting_player
 
-        # Use manually_update_current_player instead of direct assignment
         self.state.manually_update_current_player(starting_player)
 
         for player_id in range(2):
@@ -140,6 +139,13 @@ class KuhnPokerEnv(ta.Env):
             f"- '[bet]': Add 1 chip to the pot (only if no bet is on the table)\n"
             f"- '[call]': Match an opponent's bet by adding 1 chip to the pot\n"
             f"- '[fold]': Surrender your hand and let your opponent win the pot\n\n"
+            # f"Game Flow:\n"
+            # f"- Player 0 can '[check]' or '[bet]'\n"
+            # f"- If Player 0 Checks, Player 1 can '[check]' or '[bet]'\n"
+            # f"  - If Player 1 Checks, showdown occurs (higher card wins)\n"
+            # f"  - If Player 1 Bets, Player 0 must '[call]' or '[fold]'\n"
+            # f"- If Player 0 Bets, Player 1 must '[call]' or '[fold]'\n"
+            # f"- Showdown occurs if both players Check or if a bet is Called\n\n"
         )
         return prompt
 

--- a/textarena/envs/KuhnPoker/env.py
+++ b/textarena/envs/KuhnPoker/env.py
@@ -191,7 +191,6 @@ class KuhnPokerEnv(ta.Env):
             # show valid next actions
             legal_actions = ', '.join([f"[{k}]" for k in self.state.game_state["current_legal_action_tree"].keys()])
             self.state.add_observation(from_id=ta.GAME_ID, to_id=1-player_id, message=f"Your available actions are: {legal_actions}")
-
         return self.state.step()
 
     def _set_round_winner(self, player_id: int, reason: str):

--- a/textarena/envs/KuhnPoker/env.py
+++ b/textarena/envs/KuhnPoker/env.py
@@ -103,7 +103,7 @@ class KuhnPokerEnv(ta.Env):
         # set starting player
         starting_player = 1 - self.state.game_state["starting_player"]
         self.state.game_state["starting_player"] = starting_player
-        self.state.manually_update_current_player(starting_player)
+        self.state.manually_update_current_player(new_player_id=starting_player)
 
         for player_id in range(2):
             message = (

--- a/textarena/envs/KuhnPoker/env.py
+++ b/textarena/envs/KuhnPoker/env.py
@@ -103,7 +103,6 @@ class KuhnPokerEnv(ta.Env):
         # set starting player
         starting_player = 1 - self.state.game_state["starting_player"]
         self.state.game_state["starting_player"] = starting_player
-
         self.state.manually_update_current_player(starting_player)
 
         for player_id in range(2):

--- a/textarena/envs/KuhnPoker/env.py
+++ b/textarena/envs/KuhnPoker/env.py
@@ -73,7 +73,6 @@ class KuhnPokerEnv(ta.Env):
     def _check_and_start_new_round(self):
         """
         Separate method to check if a round has ended and start a new one if needed.
-        This is called from step() instead of relying on get_observation().
         """
         if self.state.game_state.get("round_ended", False):
             self.state.game_state["round_ended"] = False


### PR DESCRIPTION
This pull request focuses on improving the logic and robustness of the Kuhn Poker environment in `textarena/envs/KuhnPoker/env.py`. The changes address several issues, including incorrect game state handling, winner determination, and round transitions, while also adding safeguards to prevent errors during gameplay.

### Game state and logic fixes:
* Corrected the initialization of `current_round` in the `reset` method to start from 0 instead of 1.
* Fixed the winner determination logic in `_init_round` to compare the correct chip counts for each player.
* Added a check in `_init_round` to return immediately after setting the game as a draw or declaring a winner, avoiding further processing.

### Gameplay flow improvements:
* Added a check in the `step` method to immediately return if the game is already marked as done, ensuring no further actions are processed.
* Updated the `step` method to prevent calling `self.state.step()` after round-ending actions, avoiding player-switching issues.

### Round and game-ending logic:
* Enhanced `_set_round_winner` to directly end the game and declare a winner if the maximum number of rounds is reached, instead of waiting for another action.
* Ensured that non-final rounds start immediately after announcing the round result, improving gameplay continuity.

### Miscellaneous:
* Updated `_handle_showdown` to use `ta.GAME_ID` as the sender ID for observations, ensuring consistency in game messages.