### PR TITLE
DontSyIt: Show action with secret word

### DIFF
--- a/textarena/envs/DontSayIt/env.py
+++ b/textarena/envs/DontSayIt/env.py
@@ -86,7 +86,7 @@ class DontSayItEnv(ta.Env):
 
         # Check if the action mentions the opponent's secret word
         if self.state.game_state["target_words"][1 - player_id].lower() in action.lower():
-            reason=f"Player {player_id} mentioned the opponent's secret word."
+            reason=f"Player {player_id} mentioned the opponent's secret word: {action}"
             self.state.set_winners(player_ids=[1-player_id], reason=reason)            
 
         return self.state.step()


### PR DESCRIPTION

## Description
Show the action from the player that contained the secret word to make it clear how the player won. Currently, the message that contains the secret word is not shown if the other player says it.


## Motivation and Context
When winning Don't Say It, there is no indication how the other player said the word. It would be more rewarding/entertaining for the winning (human) player to know, what the other player said that contained the secret word.

- [ ] I have raised an issue to propose this change ([required](https://github.com/LeonGuertler/TextArena/issues) for new features and bug fixes)

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New game (adds a new game to TextArena)
- [x] Game enhancement (improves an existing game)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Refactoring (code improvement without changing functionality)

## Game-specific changes
If your PR adds or modifies a game, please specify:

- Game affected: DontSayIt
- Changes to game mechanics: No
- Changes to game UI/rendering: Yes
- Changes to game judging/rules: No

## Implementation Details
- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Testing
Did not test.

## Checklist
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the contribution guidelines. (**required**)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (**required** for bug fixes or new features)
- [ ] All new and existing tests passed.
- [ ] For game changes, I have verified that the game still runs correctly end-to-end.
