### PR TITLE
debug(Santorini): Migrate Santorini to FFAMultiPlayerState and update add_observation

### DIFF
--- a/textarena/envs/__init__.py
+++ b/textarena/envs/__init__.py
@@ -514,7 +514,7 @@ register_with_versions(id="SecretMafia-v0", entry_point="textarena.envs.SecretMa
 # register(id="TABMWP-v0", entry_point="textarena.envs.ClassicalReasoningEvals.env:ClassicalReasoningEvalsEnv", file_name="tabmwp/test.jsonl", n_samples=None)
 
 # Santorini Base Version with Fixed Worker Placement 
-register(id="SantoriniBaseFixed-v0", entry_point="textarena.envs.Santorini.env:SantoriniBaseFixedWorkerEnv")
+register_with_versions(id="SantoriniBaseFixed-v0", entry_point="textarena.envs.Santorini.env:SantoriniBaseFixedWorkerEnv", wrappers={"default": DEFAULT_WRAPPERS, "-train": DEFAULT_WRAPPERS})
 
 # BabyAiText (single-player)
 register(id="BabyAiText-v0", entry_point="textarena.envs.BabyAiText.env:BabyAiTextEnv")


### PR DESCRIPTION
## Description
This commit migrates the Santorini environment to use `ta.FFAMultiPlayerState`, replacing the older `ta.State` class for improved multiplayer game state management.

Additionally, this commit updates the observation logging to use specific `ObservationType` enums:
- Player actions are now logged with `ta.ObservationType.PLAYER_ACTION`.
- Game board representations are logged with `ta.ObservationType.GAME_BOARD`.
- Game action descriptions (e.g., worker movements) are logged with `ta.ObservationType.GAME_ACTION_DESCRIPTION`.

## Motivation and Context
Solve the bug that makes `SantoriniBaseFixed-v0` impossible to offline play.

- [x] I have raised an issue to propose this change ([required](https://github.com/LeonGuertler/TextArena/issues) for new features and bug fixes) https://github.com/LeonGuertler/TextArena/issues/137

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New game (adds a new game to TextArena)
- [ ] Game enhancement (improves an existing game)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Refactoring (code improvement without changing functionality)

## Game-specific changes
If your PR adds or modifies a game, please specify:
- `SantoriniBaseFixed-v0` bug fix

## Implementation Details
- [x] Migrate from State to FFAMultiPlayerState
- [x] Add observation type when doing add_observation


## Testing
Describe the tests you've done to verify your changes. For game-specific changes, describe how you've tested the game mechanics.
Passed all tests

## Checklist
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the contribution guidelines. (**required**)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. (**required** for bug fixes or new features)
- [ ] All new and existing tests passed.
- [ ] For game changes, I have verified that the game still runs correctly end-to-end.
