### PR TITLE
fix: pass correct from_id to add_observation in WordleEnv.step

### DIFF
--- a/textarena/envs/Wordle/env.py
+++ b/textarena/envs/Wordle/env.py
@@ -54,7 +54,7 @@ class WordleEnv(ta.Env):
 
     def step(self, action: str) -> Tuple[bool, ta.Info]:
         player_id = self.state.current_player_id
-        self.state.add_observation(message=action, observation_type=ta.ObservationType.PLAYER_ACTION)
+        self.state.add_observation(message=action, observation_type=ta.ObservationType.PLAYER_ACTION, from_id=player_id, to_id=-1)
         match = re.search(r"\[(\w+)\]", action) # Extract the guess using regex
 
         if match is None:


### PR DESCRIPTION
This PR is a re-submission of #185 .
The previous PR was closed only to move the changes to a dedicated fix branch.
No functional changes compared to the original PR.

## Description

Fixed a bug in WordleEnv.step where player actions were incorrectly attributed to the `GAME_ID`. This caused the observation logs to display `[GAME]` for player guesses instead of `[Player]`.

## Changes

Explicitly pass `from_id=player_id` in `add_observation` when recording PLAYER_ACTION.

Comparison
- Before:
  ```
  [GAME] [planets]
  [GAME] You submitted [planets].
  ```

- After:
  ```
  [Player] [planets]
  [GAME] You submitted [planets].
  ```