### PR TITLE
fix: correct ground_truth comparison in BanditEnv

### DIFF
--- a/textarena/envs/Bandit/env.py
+++ b/textarena/envs/Bandit/env.py
@@ -41,8 +41,9 @@ class BanditEnv(ta.Env):
             button = match.group(1)
             if button in self.buttons:
                 if self.state.turn == self.num_turns:
-                    if button == self.state.game_state['ground_truth']: self.state.set_outcome(reward=1.0, reason=f"Congratulations! You chose the correct button.") 
-                    else:                                               self.state.set_outcome(reward=self._regret(button), reason=f"You chose an incorrect button.") 
+                    best_button = max(self.state.game_state['ground_truth'], key=lambda b: self.state.game_state['ground_truth'][b])
+                    if button == best_button: self.state.set_outcome(reward=1.0, reason=f"Congratulations! You chose the correct button.")
+                    else:                     self.state.set_outcome(reward=self._regret(button), reason=f"You chose an incorrect button.") 
                 else:
                     reward = 1.0 if random.random() < self.state.game_state['ground_truth'][button] else 0.0
                     self.state.game_state['history'][button].append(reward)


### PR DESCRIPTION
## Summary

- `ground_truth` in `BanditEnv` is a **dict** mapping button names to probabilities (e.g. `{"red": 0.6, "blue": 0.3, ...}`), but the final-turn winner check compares a button string directly against this dict (`button == self.state.game_state['ground_truth']`), which **always evaluates to `False`**.
- This means the player can **never** be recognized as having chosen the correct button — every game ends with an incorrect outcome and a regret-based reward.
- Fix: find the button with the highest probability via `max(..., key=...)`, then compare the player's choice against that.

## Reproduction

```python
ground_truth = {"red": 0.6, "blue": 0.3}
button = "red"
print(button == ground_truth)  # False — string vs dict, always False
```

## Test plan

- [x] Verified that `_regret()` already correctly uses `ground_truth` as a dict (calls `.values()` and indexes by button name), confirming this is a dict, not a string.
- [x] Confirmed the fix matches the intended semantics: reward 1.0 when the player picks the highest-probability button.