### PR TITLE
Fix SyntaxError in Klondike-v0

### DIFF
--- a/textarena/envs/Klondike/env.py
+++ b/textarena/envs/Klondike/env.py
@@ -116,15 +116,15 @@ class KlondikeEnv(ta.Env):
                     self.state.set_outcome(
                         reward=52, reason="Congratulations! You've won Klondike Solitaire!"
                     )
-            elif self.state.game_state["turn_count"] >= self.max_turns:
-                # Partial reward based on cards in foundations (1 point per card)
-                cards_in_foundations = sum(
-                    len(pile) for pile in self.klondike.foundations
-                )
-                self.state.set_outcome(
-                    reward=cards_in_foundations,
-                    reason=f"Game over! You reached the maximum of {self.max_turns} turns. Score: {cards_in_foundations} cards in foundations.",
-                )
+                elif self.state.game_state["turn_count"] >= self.max_turns:
+                    # Partial reward based on cards in foundations (1 point per card)
+                    cards_in_foundations = sum(
+                        len(pile) for pile in self.klondike.foundations
+                    )
+                    self.state.set_outcome(
+                        reward=cards_in_foundations,
+                        reason=f"Game over! You reached the maximum of {self.max_turns} turns. Score: {cards_in_foundations} cards in foundations.",
+                    )
 
             # Update board observation
             self._observe_state()


### PR DESCRIPTION
Cloning `main` and trying to import the Klondike env fails at parse time:

```bash
git clone --depth 1 https://github.com/LeonGuertler/TextArena.git
cd TextArena
python -m py_compile textarena/envs/Klondike/env.py
```

```
  File "textarena/envs/Klondike/env.py", line 119
    elif self.state.game_state["turn_count"] >= self.max_turns:
    ^^^^
SyntaxError: invalid syntax
```

So `ta.make("Klondike-v0")` has been broken since the env was added in #154.

## Cause & fix

Line 119's `elif` was indented to the outer if/else level, but the surrounding `else:` had already opened — Python can't chain `elif` onto a closed `else`. From context it was meant to chain onto `if self.klondike.is_won():` inside the `else` block. Indented the `elif` and its body one level. No behavior change beyond making the module importable.

## Verification

```bash
python -m py_compile textarena/envs/Klondike/env.py                                        # exit 0
python -c "import textarena as ta; ta.make('Klondike-v0').reset(num_players=1, seed=42)"   # OK
```